### PR TITLE
Transition from Python 2.7 to Python 3.7

### DIFF
--- a/acra/extract/iterquant.py
+++ b/acra/extract/iterquant.py
@@ -10,7 +10,7 @@ config = configs.read_default_config()
 
 allimpacts = config['only-impacts'] if config.get('only-impacts', 'all') != 'all' else impacts.allimpacts
 
-print "Collecting all available models."
+print("Collecting all available models.")
 allmodels = set()
 for (batch, rcp, model, realization, pvals, targetdir) in configs.iterate_valid_targets(config, allimpacts, verbose=False):
     allmodels.add(model)
@@ -21,7 +21,7 @@ if not os.path.exists(outdir):
     os.mkdir(outdir)
 
 for model in allmodels:
-    print "Processing", model
+    print("Processing", model)
     modeloutdir = os.path.join(outdir, model)
     if not os.path.exists(modeloutdir):
         os.mkdir(modeloutdir)

--- a/acra/extract/lib/bundles.py
+++ b/acra/extract/lib/bundles.py
@@ -25,7 +25,7 @@ def get_yearses(fp, yearses):
     if yearses[0][0] < 1000:
         # Just head and tail or tail of results
         reader = csv.reader(fp)
-        reader.next()
+        next(reader)
         values = [float(row[1]) for row in reader]
 
         # Return a list of all requested subsets
@@ -73,7 +73,7 @@ def get_years(fp, years, column=2):
     """Return the results for the given years, as specifically requested years."""
     results = []
     reader = csv.reader(fp)
-    reader.next()
+    next(reader)
 
     years_ii = 0 # Start by looking for the first year
     for row in reader:

--- a/acra/extract/lib/configs.py
+++ b/acra/extract/lib/configs.py
@@ -2,11 +2,11 @@
 
 import sys, os
 import yaml
-import results
+from . import results
 
 def read_default_config():
     if len(sys.argv) < 2:
-        print "Specify the configuration file on the command-line."
+        print("Specify the configuration file on the command-line.")
         exit()
 
     return read_config(sys.argv[1])
@@ -18,7 +18,7 @@ def read_config(filename):
         allmodels = config.get('only-models', 'all')
         allow_partial = config.get('allow-partial', 1)
         if allmodels != 'all' and allow_partial > 0 and allow_partial < len(allmodels):
-            print "Warning: allow-partial specifies a value greater than the number of included models.  Setting equal to the number of models."
+            print("Warning: allow-partial specifies a value greater than the number of included models.  Setting equal to the number of models.")
             config['allow-partial'] = len(allmodels)
         if allmodels != 'all' and allow_partial == 0: # interpret 0 (all) as all allowed
             config['allow-partial'] = len(allmodels)
@@ -32,7 +32,7 @@ def iterate_valid_targets(config, impacts, verbose=True):
     root = config['results-root']
     do_montecarlo = config['do-montecarlo']
     do_adaptation = config['do-adaptation'] == True
-    batches = range(config['batches']) if isinstance(config['batches'], int) else config['batches']
+    batches = list(range(config['batches'])) if isinstance(config['batches'], int) else config['batches']
     allmodels = config['only-models'] if config.get('only-models', 'all') != 'all' else None
     checks = config['checks']
     do_rcp_only = config['only-rcp']
@@ -44,7 +44,7 @@ def iterate_valid_targets(config, impacts, verbose=True):
         prefix = 'batch-adapt-'
         if batch_presuffix:
             prefix += batch_presuffix + '-'
-        batches = map(lambda i: prefix + str(i), batches)
+        batches = [prefix + str(i) for i in batches]
 
     if do_montecarlo:
         iterator = results.iterate_montecarlo(root, batches=batches)
@@ -56,17 +56,17 @@ def iterate_valid_targets(config, impacts, verbose=True):
     for (batch, rcp, model, realization, pvals, targetdir) in iterator:
         if checks is not None and not results.directory_contains(targetdir, checks):
             if verbose:
-                print targetdir, "missing", checks
+                print(targetdir, "missing", checks)
             continue
 
         if do_rcp_only and rcp != do_rcp_only:
-            print targetdir, "not", do_rcp_only
+            print(targetdir, "not", do_rcp_only)
             continue
         if do_realization_only and realization != do_realization_only:
-            print targetdir, "not", do_realization_only
+            print(targetdir, "not", do_realization_only)
             continue
         if allmodels is not None and model not in allmodels:
-            print targetdir, "not in", allmodels
+            print(targetdir, "not in", allmodels)
             continue
 
         if impacts is None:

--- a/acra/extract/lib/results.py
+++ b/acra/extract/lib/results.py
@@ -103,7 +103,7 @@ def iterate_byp(root, batches=None):
 
     if batches == 'truehist':
         # If the truehist scenario is request, only look for this
-        for pdir in pdirs.keys():
+        for pdir in list(pdirs.keys()):
             targetdir = os.path.join(root, pdir, 'truehist')
             if not os.path.exists(targetdir) or 'pvals.txt' not in os.listdir(targetdir):
                 continue # Ignore if no pval file
@@ -116,7 +116,7 @@ def iterate_byp(root, batches=None):
         return
 
     # Look only for the named directories
-    for pdir in pdirs.keys():
+    for pdir in list(pdirs.keys()):
         if not os.path.exists(os.path.join(root, pdir)):
             continue
 

--- a/acra/extract/lib/weights.py
+++ b/acra/extract/lib/weights.py
@@ -46,7 +46,7 @@ def weighted_values(values, weights):
       values: Dictionary of GCM -> result value
       weights: Dictionary of GCM -> GCM weight
     """
-    models = values.keys()
+    models = list(values.keys())
     values_list = [values[model] for model in models if model in weights]
     weights_list = [weights[model] for model in models if model in weights]
 
@@ -60,7 +60,7 @@ class WeightedECDF(StepFunction):
         self.expected = sum(np.array(values) * np.array(weights)) / sum(weights)
 
         # Creat the cummulative sum that represents this ECDF
-        order = sorted(range(len(values)), key=lambda ii: values[ii])
+        order = sorted(list(range(len(values))), key=lambda ii: values[ii])
         self.values = np.array([values[ii] for ii in order])
         self.weights = [weights[ii] for ii in order]
 

--- a/acra/extract/quantiles.py
+++ b/acra/extract/quantiles.py
@@ -10,7 +10,7 @@ outdir = config['output-dir']
 
 output_format = config.get('output-format', "edfcsv")
 if output_format not in ['edfcsv', 'valuescsv']:
-    print "Error: output-format must be edfcsv or valuescsv."
+    print("Error: output-format must be edfcsv or valuescsv.")
     exit()
     
 do_gcmweights = config.get('do-gcmweights', True)
@@ -20,7 +20,7 @@ allimpacts = config['only-impacts'] if config.get('only-impacts', 'all') != 'all
 suffix = configs.get_suffix(config)
 column = config['column']
 allow_partial = config['allow-partial']
-batches = range(config['batches']) if isinstance(config['batches'], int) else config['batches']
+batches = list(range(config['batches'])) if isinstance(config['batches'], int) else config['batches']
 
 evalpvals = list(np.linspace(.01, .99, 99))
 
@@ -32,7 +32,7 @@ if do_yearsets:
     else:
         yearses = [(2020, 2039), (2040, 2059), (2080, 2099)]
 else:
-    years = range(2000, 2100)
+    years = list(range(2000, 2100))
 
 if do_yearsetmeans:
     combine_years = np.mean
@@ -43,13 +43,13 @@ if not os.path.exists(outdir):
     os.mkdir(outdir)
 
 for impact in allimpacts:
-    print impact
+    print(impact)
 
     # Collect all available results
     data = {} # { rcp-year0 => { region => { batch-realization => { model => value } } } }
 
     for (batch, rcp, model, realization, pvals, targetdir) in configs.iterate_valid_targets(config, [impact]):
-        print targetdir
+        print(targetdir)
 
         collection = batch + '-' + realization
 
@@ -93,11 +93,11 @@ for impact in allimpacts:
             with open(os.path.join(outdir, impact + '-' + dist + '.csv'), 'w') as csvfp:
                 writer = csv.writer(csvfp, quoting=csv.QUOTE_MINIMAL)
                 if output_format == 'edfcsv':
-                    writer.writerow(['region'] + map(lambda q: 'q' + str(q), evalpvals))
+                    writer.writerow(['region'] + ['q' + str(q) for q in evalpvals])
                 elif output_format == 'valuescsv':
                     writer.writerow(['region', 'collection', 'model', 'value', 'weight'])
 
-                for region in data[dist].keys():
+                for region in list(data[dist].keys()):
 
                     allvalues = []
                     allweights = []
@@ -106,13 +106,13 @@ for impact in allimpacts:
 
                     for collection in data[dist][region]:
                         if not do_gcmweights and allow_partial == 0:
-                            print "Warning: Not using GCM weights, but still using the number of GCM weighted models for limiting batches.  Set allow-partial > 0 to remove warning."
+                            print("Warning: Not using GCM weights, but still using the number of GCM weighted models for limiting batches.  Set allow-partial > 0 to remove warning.")
                             allow_partial = len(model_weights)
                         if len(data[dist][region][collection]) >= (allow_partial if allow_partial > 0 else len(model_weights)):
                             if do_gcmweights:
                                 (values, valueweights) = weights.weighted_values(data[dist][region][collection], model_weights)
                                 if len(values) == 0:
-                                    print "Cannot find any values for weighted models."
+                                    print("Cannot find any values for weighted models.")
                                     continue
                                 if isinstance(values[0], list):
                                     for ii in range(len(values)):
@@ -123,15 +123,15 @@ for impact in allimpacts:
                                 else:
                                     allvalues += values
                                     allweights += valueweights
-                                    allmodels += data[dist][region][collection].keys()
+                                    allmodels += list(data[dist][region][collection].keys())
                                     allcollections += [collection] * len(values)
                             else:
-                                allvalues += data[dist][region][collection].values()
+                                allvalues += list(data[dist][region][collection].values())
                                 allweights += [1.] * len(data[dist][region][collection])
-                                allmodels += data[dist][region][collection].keys()
+                                allmodels += list(data[dist][region][collection].keys())
                                 allcollections += [collection] * len(data[dist][region][collection])
 
-                    print dist, region, len(allvalues)
+                    print(dist, region, len(allvalues))
                     if len(allvalues) == 0:
                         continue
 

--- a/benchmark/readncdf.py
+++ b/benchmark/readncdf.py
@@ -12,22 +12,22 @@ for root, dirs, files in os.walk(sys.argv[1]):
         if match:
             variable = match.group(1)
             filepath = os.path.join(root, filename)
-            print "Found %s: %s" % (variable, filepath)
+            print("Found %s: %s" % (variable, filepath))
 
             memstart = resource.getrusage(resource.RUSAGE_SELF)
             timestart = time.time()
             rootgrp = Dataset(filepath, 'r', format='NETCDF4')
             alldata = rootgrp.variables[variable][:,:]
-            print alldata[:, 100]
+            print(alldata[:, 100])
             size = alldata.size
             del alldata
             timeend = time.time()
-            print timestart, timeend
+            print(timestart, timeend)
             memend = resource.getrusage(resource.RUSAGE_SELF)
 
-            print size, ((memend[2] - memstart[2])*resource.getpagesize())/1000000.0, timeend - timestart
+            print(size, ((memend[2] - memstart[2])*resource.getpagesize())/1000000.0, timeend - timestart)
 
             totalsize += size
             totaltime += timeend - timestart
 
-print totalsize / totaltime
+print(totalsize / totaltime)

--- a/gcp/extract/lib/bundles.py
+++ b/gcp/extract/lib/bundles.py
@@ -21,7 +21,7 @@ __version__ = "$Revision$"
 import os, csv
 import numpy as np
 from netCDF4 import Dataset
-import configs
+from . import configs
 
 deltamethod_vcv = None
 
@@ -66,7 +66,7 @@ def read(filepath, column='rebased', deltamethod=False):
     try:
         rootgrp = Dataset(filepath, 'r', format='NETCDF4')
     except:
-        print "Error: Cannot read %s" % filepath
+        print("Error: Cannot read %s" % filepath)
         exit()
 
     years = rootgrp.variables['year'][:]
@@ -88,7 +88,7 @@ def read(filepath, column='rebased', deltamethod=False):
     rootgrp.close()
 
     # Correct bad regions in costs
-    if filepath[-10:] == '-costs.nc4' and not isinstance(regions[0], str) and not isinstance(regions[0], unicode) and np.isnan(regions[0]):
+    if filepath[-10:] == '-costs.nc4' and not isinstance(regions[0], str) and not isinstance(regions[0], str) and np.isnan(regions[0]):
         rootgrp = Dataset(filepath.replace('-costs.nc4', '.nc4'), 'r', format='NETCDF4')
         regions = rootgrp.variables['regions'][:]
         rootgrp.close()
@@ -119,8 +119,8 @@ def iterate_regions(filepath, column, config={}):
                 foundindex = ii
                 break
         if foundindex is None:
-            print np.sum(np.abs(deltamethod_vcv - config['multiimpact_vcv'][:deltamethod_vcv.shape[0], :deltamethod_vcv.shape[1]]))
-            print np.sum(np.abs(deltamethod_vcv - config['multiimpact_vcv'][deltamethod_vcv.shape[0]:, deltamethod_vcv.shape[1]:]))
+            print(np.sum(np.abs(deltamethod_vcv - config['multiimpact_vcv'][:deltamethod_vcv.shape[0], :deltamethod_vcv.shape[1]])))
+            print(np.sum(np.abs(deltamethod_vcv - config['multiimpact_vcv'][deltamethod_vcv.shape[0]:, deltamethod_vcv.shape[1]:])))
         assert foundindex is not None, "Cannot find the VCV for " + filepath + " within the master VCV."
         newdata = np.zeros(tuple([config['multiimpact_vcv'].shape[0]] + list(data.shape[1:])))
         if len(data.shape) == 2:

--- a/gcp/extract/lib/configs.py
+++ b/gcp/extract/lib/configs.py
@@ -3,11 +3,11 @@
 import sys, os, re
 import yaml, csv
 import numpy as np
-import results
+from . import results
 
 def consume_config():
     if len(sys.argv) < 2:
-        print "Please specify a configuration (.yml) file."
+        print("Please specify a configuration (.yml) file.")
         exit()
     
     argv = []
@@ -44,7 +44,7 @@ def handle_multiimpact_vcv(config):
         with open(config['multiimpact_vcv'], 'r') as fp:
             reader = csv.reader(fp)
             for row in reader:
-                multiimpact_vcv.append(map(float, row))
+                multiimpact_vcv.append(list(map(float, row)))
         config['multiimpact_vcv'] = np.array(multiimpact_vcv)
     else:
         config['multiimpact_vcv'] = None
@@ -88,20 +88,20 @@ def iterate_valid_targets(root, config, impacts=None, verbose=True):
 
         if checks is not None and not results.directory_contains(targetdir, checks):
             if verbose:
-                print targetdir, "missing", checks
+                print(targetdir, "missing", checks)
             continue
 
         if do_rcp_only and rcp != do_rcp_only:
-            print targetdir, "not", do_rcp_only
+            print(targetdir, "not", do_rcp_only)
             continue
         if do_iam_only and iam != do_iam_only:
-            print targetdir, "not", do_iam_only
+            print(targetdir, "not", do_iam_only)
             continue
         if do_ssp_only and ssp != do_ssp_only:
-            print targetdir, "not", do_ssp_only
+            print(targetdir, "not", do_ssp_only)
             continue
         if allmodels is not None and model not in allmodels:
-            print targetdir, "not in", allmodels
+            print(targetdir, "not in", allmodels)
             continue
 
         if impacts is None:
@@ -111,7 +111,7 @@ def iterate_valid_targets(root, config, impacts=None, verbose=True):
                     allthere = True
                     for name in dmpath:
                         if not os.path.isdir(dmpath[name]):
-                            print "deltamethod", dmpath[name], "missing 1"
+                            print("deltamethod", dmpath[name], "missing 1")
                             allthere = False
                             break
                     if allthere:
@@ -121,7 +121,7 @@ def iterate_valid_targets(root, config, impacts=None, verbose=True):
                     observations += 1
                     yield batch, rcp, model, iam, ssp, targetdir
                 elif verbose:
-                    print "deltamethod", get_deltamethod_path(targetdir, config), "missing 2"
+                    print("deltamethod", get_deltamethod_path(targetdir, config), "missing 2")
             else:
                 observations += 1
                 yield batch, rcp, model, iam, ssp, targetdir
@@ -133,17 +133,17 @@ def iterate_valid_targets(root, config, impacts=None, verbose=True):
                         if isinstance(targetdir, dict):
                             dmpath = os.path.join(multipath(get_deltamethod_path(targetdir, config), impact), impact + ".nc4")
                             if not os.path.isfile(dmpath):
-                                print "deltamethod", dmpath, "missing 3"
+                                print("deltamethod", dmpath, "missing 3")
                                 continue
                         elif not os.path.isfile(os.path.join(targetdir, impact + ".nc4")):
-                            print "deltamethod", dmpath, "missing 4"
+                            print("deltamethod", dmpath, "missing 4")
                             continue
                     observations += 1
                     yield batch, rcp, model, iam, ssp, targetdir
                     break
 
     if observations == 0:
-        print message_on_none
+        print(message_on_none)
 
 def is_parallel_deltamethod(config):
     dmconf = config.get('deltamethod', False)
@@ -219,9 +219,9 @@ def get_regions(config, allregions):
     if 'global' in regions:
         regions = ['' if x == 'global' else x for x in regions]
     if 'countries' in regions:
-        regions = filter(lambda x: x != 'countries', regions) + filter(lambda x: len(x) == 3, allregions)
+        regions = [x for x in regions if x != 'countries'] + [x for x in allregions if len(x) == 3]
     if 'funds' in regions:
-        regions = filter(lambda x: x != 'funds', regions) + filter(lambda x: x[:5] == 'FUND-', allregions)
+        regions = [x for x in regions if x != 'funds'] + [x for x in allregions if x[:5] == 'FUND-']
 
     return regions
 

--- a/gcp/extract/lib/results.py
+++ b/gcp/extract/lib/results.py
@@ -20,7 +20,7 @@ __version__ = "$Revision$"
 
 import os, csv, glob, traceback, re
 import numpy as np
-import configs, bundles
+from . import configs, bundles
 
 debug = True
 rcps = ['rcp45', 'rcp85']
@@ -139,9 +139,9 @@ def sum_into_data(root, basenames, columns, config, transforms, vectransforms):
     for batch, rcp, gcm, iam, ssp, targetdir in configs.iterate_valid_targets(root, config, basenames):
         message_on_none = "No valid results sets found within directories."
         if isinstance(targetdir, str):
-            print targetdir
+            print(targetdir)
         else:
-            print targetdir[targetdir.keys()[0]], "..."
+            print(targetdir[list(targetdir.keys())[0]], "...")
 
         # Ensure that all basenames are accounted for
         foundall = True
@@ -182,14 +182,14 @@ def sum_into_data(root, basenames, columns, config, transforms, vectransforms):
                             data[filestuff][rowstuff][(batch, gcm, iam)] += value
                         observations += 1
             except:
-                print "Failed to read " + fullpath
+                print("Failed to read " + fullpath)
                 traceback.print_exc()
                 if debug:
                     exit()
 
-    print "Observations:", observations
+    print("Observations:", observations)
     if observations == 0:
-        print message_on_none
+        print(message_on_none)
     return data, years
 
 def deltamethod_variance(value, config):

--- a/gcp/extract/lib/weights.py
+++ b/gcp/extract/lib/weights.py
@@ -33,7 +33,7 @@ def get_weights_april2016(rcp):
 
     with open('/shares/gcp/climate/BCSD/SMME/SMME-weights/' + rcp + '_2090_SMME_edited_for_April_2016.tsv', 'rU') as tsvfp:
         reader = csv.reader(tsvfp, delimiter='\t')
-        header = reader.next()
+        header = next(reader)
         for row in reader:
             model = row[1].split('_')[0].strip('*').lower()
             weight = float(row[2])
@@ -49,7 +49,7 @@ def get_weights_march2018(rcp):
 
     with open('/shares/gcp/climate/BCSD/SMME/SMME-weights/' + rcp + '_SMME_weights.tsv', 'rU') as tsvfp:
         reader = csv.reader(tsvfp, delimiter='\t')
-        header = reader.next()
+        header = next(reader)
         for row in reader:
             model = row[1].strip('*').lower()
             if '_' in model:
@@ -64,7 +64,7 @@ def get_weights_march2018(rcp):
 
 def weighted_values(values, weights):
     """Takes a dictionary of model => value"""
-    models = values.keys()
+    models = list(values.keys())
     values_list = [values[model] for model in models if model in weights]
     weights_list = [weights[model] for model in models if model in weights]
 
@@ -84,7 +84,7 @@ class WeightedECDF(StepFunction):
         
         self.expected = sum(np.array(values) * np.array(weights)) / sum(weights)
 
-        order = sorted(range(len(values)), key=lambda ii: values[ii])
+        order = sorted(list(range(len(values))), key=lambda ii: values[ii])
         self.values = np.array([values[ii] for ii in order])
         self.weights = [weights[ii] for ii in order]
 
@@ -117,7 +117,7 @@ class WeightedECDF(StepFunction):
     @staticmethod
     def encode_evalqvals(evalqvals):
         encoder = {'mean': 2, 'sdev': 3}
-        return map(lambda p: p if isinstance(p, float) else encoder[p], evalqvals)
+        return [p if isinstance(p, float) else encoder[p] for p in evalqvals]
 
 if __name__ == '__main__':
     import sys
@@ -128,9 +128,9 @@ if __name__ == '__main__':
         if rcp == 'historical':
             continue
         weights = get_weights(rcp)
-        print weights
+        print(weights)
         for gcm in os.listdir(os.path.join(batchdir, rcp)):
             try:
-                print gcm, weights[gcm.lower()]
+                print(gcm, weights[gcm.lower()])
             except:
-                print "Cannot find weight for %s under %s" % (gcm, rcp)
+                print("Cannot find weight for %s under %s" % (gcm, rcp))

--- a/gcp/extract/lib/weights_vcv.py
+++ b/gcp/extract/lib/weights_vcv.py
@@ -58,7 +58,7 @@ class WeightedGMCDF(object):
     @staticmethod
     def encode_evalqvals(evalqvals):
         encoder = {'mean': 2}
-        return map(lambda p: p if isinstance(p, float) else encoder[p], evalqvals)
+        return [p if isinstance(p, float) else encoder[p] for p in evalqvals]
 
 if __name__ == '__main__':
     ## Example between R and python
@@ -82,5 +82,5 @@ if __name__ == '__main__':
     pp = [0.04261865, 0.57543051, 0.09961645, 0.13132502, 0.68372897, 0.89938713, 0.37682157, 0.25068274, 0.72613404, 0.92355014]
     
     dist = WeightedGMCDF(means, variances, weights)
-    print dist.inverse(pp)
+    print(dist.inverse(pp))
     # [-2.708582712985005, 0.7720415676939508, -2.152969315647189, -1.8999500392063315, 1.1698917665106159, 1.955783738182657, -0.0641650435162273, -0.9150700927430755, 1.3660161904436894, 2.004650382993468]

--- a/gcp/extract/quantiles.py
+++ b/gcp/extract/quantiles.py
@@ -43,10 +43,10 @@ if configs.is_parallel_deltamethod(config):
     parallel_deltamethod_data, parallel_deltamethod_years = results.sum_into_data(config['deltamethod'], basenames, columns, config2, transforms, vectransforms)
 
 for filestuff in data:
-    print "Creating file: " + str(filestuff)
+    print("Creating file: " + str(filestuff))
     
     if configs.is_parallel_deltamethod(config) and filestuff not in parallel_deltamethod_data:
-        print str(filestuff) + " is not in delta method output. Skipping model specification..."
+        print(str(filestuff) + " is not in delta method output. Skipping model specification...")
         continue
     
     with open(configs.csv_makepath(filestuff, config), 'w') as fp:
@@ -54,7 +54,7 @@ for filestuff in data:
         rownames = configs.csv_rownames(config)
 
         if output_format == 'edfcsv':
-            writer.writerow(rownames + map(lambda q: q if isinstance(q, str) else 'q' + str(int(q * 100)), evalqvals))
+            writer.writerow(rownames + [q if isinstance(q, str) else 'q' + str(int(q * 100)) for q in evalqvals])
             if configs.is_parallel_deltamethod(config):
                 encoded_evalqvals = weights_vcv.WeightedGMCDF.encode_evalqvals(evalqvals)
             else:
@@ -63,8 +63,8 @@ for filestuff in data:
             writer.writerow(rownames + ['batch', 'gcm', 'iam', 'value', 'weight'])
 
             
-        for rowstuff in configs.csv_sorted(data[filestuff].keys(), config):
-            print "Outputing row: " + str(rowstuff)
+        for rowstuff in configs.csv_sorted(list(data[filestuff].keys()), config):
+            print("Outputing row: " + str(rowstuff))
             if do_gcmweights:
                 model_weights = weights.get_weights(configs.csv_organized_rcp(filestuff, rowstuff, config))
 
@@ -82,7 +82,7 @@ for filestuff in data:
                     try:
                         weight = model_weights[gcm.lower()]
                     except:
-                        print "Warning: No weight available for %s, so dropping." % gcm
+                        print("Warning: No weight available for %s, so dropping." % gcm)
                         weight = 0.
                 else:
                     weight = 1.

--- a/gcp/validate/compare.py
+++ b/gcp/validate/compare.py
@@ -17,7 +17,7 @@ for ii in range(reader1.variables[column].shape[1]):
     data1 = reader1.variables[column][:, ii]
     data2 = reader2.variables[column][:, ii]
     if not np.allclose(data1, data2): #, equal_nan=True):
-        print "Failed on region", ii, regions[ii]
+        print("Failed on region", ii, regions[ii])
         first = np.where(np.logical_not(np.isclose(data1, data2)))[0][0]
-        print first, data1[first], data2[first]
+        print(first, data1[first], data2[first])
 

--- a/gcp/validate/distribution.py
+++ b/gcp/validate/distribution.py
@@ -4,8 +4,8 @@ import xarray as xr
 
 fullpath = "/shares/gcp/climate/BCSD/hierid/popwt/daily/tas/{scenario}/CCSM4/{year}/1.6.nc4"
 
-histyears = range(1991, 2001)
-lateyears = range(2090, 2100)
+histyears = list(range(1991, 2001))
+lateyears = list(range(2090, 2100))
 
 hierids = ['USA.10.367', 'ETH.8.39.Rce1a51acb321322b', 'AUS.11.1392', 'AGO.11.94', 'OMN.8', 'ARE.1', 'USA.27.1625']
 
@@ -31,7 +31,7 @@ mintemp = int(np.floor(mintemp))
     
 with open("tas-dists.csv", 'w') as fp:
     writer = csv.writer(fp)
-    aboves = range(mintemp, int(maxtemp)+2)
+    aboves = list(range(mintemp, int(maxtemp)+2))
     writer.writerow(['hierid', 'period'] + ['abv%d' % tt for tt in aboves])
     for hierid in hierids:
         counts = list(np.bincount(np.int_(histdists[hierid]) - mintemp))

--- a/lib/header.py
+++ b/lib/header.py
@@ -72,7 +72,7 @@ def parse(fp):
             header['version'] = chunks[1].strip()
             addcall = None
         elif title == 'dependencies':
-            header['dependencies'] = map(lambda s: s.strip(), chunks[1].split(','))
+            header['dependencies'] = [s.strip() for s in chunks[1].split(',')]
             addcall = None
         elif title == 'variables':
             header['variables'] = {}
@@ -109,7 +109,7 @@ if __name__ == '__main__':
     def rlinput(prompt, prefill=''):
         readline.set_startup_hook(lambda: readline.insert_text(prefill))
         try:
-            return raw_input(prompt)
+            return input(prompt)
         finally:
             readline.set_startup_hook()
 
@@ -117,16 +117,16 @@ if __name__ == '__main__':
 
     if filename_in[-4:].lower() == '.fgh':
         filename_out = filename_in
-        print "Output file: ", filename_out
+        print("Output file: ", filename_out)
         filename_in = None
     else:
-        print "Input File: ", filename_in
+        print("Input File: ", filename_in)
         filename_out = rlinput("Output File: ", filename_in)
 
     oneline = rlinput("One line description: ")
     version = rlinput("Version: ")
 
-    print "Enter the dependencies (blank to finish):"
+    print("Enter the dependencies (blank to finish):")
     dependencies = []
     while True:
         dependency = rlinput("Version: ")
@@ -134,7 +134,7 @@ if __name__ == '__main__':
             break
         dependencies.append(dependency)
 
-    print "Define the variables (blank to finish):"
+    print("Define the variables (blank to finish):")
     variables = {}
     while True:
         name = rlinput("Variable Name: ")
@@ -145,7 +145,7 @@ if __name__ == '__main__':
         unit = rlinput("Units: ")
         variables[name] = (desc, unit)
 
-    print "Define the sources (blank to finish):"
+    print("Define the sources (blank to finish):")
     sources = {}
     while True:
         name = rlinput("Source Name: ")
@@ -155,7 +155,7 @@ if __name__ == '__main__':
         desc = rlinput("Short description: ")
         sources[name] = desc
 
-    print "Enter a description (type Ctrl-D on a blank line to finish):"
+    print("Enter a description (type Ctrl-D on a blank line to finish):")
     description = '\n'.join(sys.stdin.readlines())
     if not description.strip():
         description = None


### PR DESCRIPTION
Transition the scripts from Python 2.7 to Python 3.7.

Our focus is on the quantiles.py and single.py scripts in gcp/extract.

As the scripts don't have have a testing framework we're going to rerun the updated code on old workflows and check the output.